### PR TITLE
Remove Skelton loaders

### DIFF
--- a/app/pages/homepage.py
+++ b/app/pages/homepage.py
@@ -33,7 +33,7 @@ class StartPage(tk.Frame):
 
         # Center content
         self.content_frame = Frame(self, background='#2c3e50')
-        self.content_frame.grid(row=1, column=0, pady=5, padx=5, sticky='n')
+        self.content_frame.grid(row=1, column=0, pady=(100, 0), padx=5, sticky='n')
         self.content_frame.grid_rowconfigure(0, weight=1)
         self.content_frame.grid_columnconfigure(0, weight=1)
 
@@ -75,20 +75,15 @@ class StartPage(tk.Frame):
             "PE Ratio:", "Return on Equity Ratio:", "Debt to Equity Ratio:", "Net Profit Margin:"
         ]
         self.value_labels = {}
-        self.skeleton_loaders = {}
-        self.animation_ids = {}
-        self.row_info = {}
 
         for i, label in enumerate(labels):
             lbl = Label(self.results_frame, text=label, width=25, anchor="w", font=self.label_font, background='#34495e',
                         fg='#ecf0f1')
             lbl.grid(row=i + 1, column=0, padx=5, pady=5, sticky='w')
-            canvas = Canvas(self.results_frame, width=200, height=20, bg='#34495e', highlightthickness=0)
-            canvas.grid(row=i + 1, column=1, padx=5, pady=5, sticky='w')
-            self.skeleton_loaders[label] = canvas
-            self.value_labels[label] = Label(self.results_frame, text="", width=25, anchor="w", font=self.label_font,
-                                             background='#34495e', fg='#ecf0f1')
-            self.row_info[label] = {'row': i + 1, 'column': 1}
+            value_label = Label(self.results_frame, text="", width=25, anchor="w", font=self.label_font,
+                                background='#34495e', fg='#ecf0f1')
+            value_label.grid(row=i + 1, column=1, padx=5, pady=5, sticky='w')
+            self.value_labels[label] = value_label
 
         self.parent.bind('<Return>', self.analyze)
 

--- a/app/pages/homepage.py
+++ b/app/pages/homepage.py
@@ -45,7 +45,8 @@ class StartPage(tk.Frame):
         self.input_frame = Frame(self.content_frame, background='#34495e', bd=2, relief=SOLID)
         self.input_frame.grid(row=0, column=0, pady=5, padx=5, sticky='n')
 
-        self.stock_symbol_text = Label(self.input_frame, text="Enter Stock Symbol:", font=self.label_font, background='#34495e', fg='#ecf0f1')
+        self.stock_symbol_text = Label(self.input_frame, text="Enter Stock Symbol:", font=self.label_font,
+                                       background='#34495e', fg='#ecf0f1')
         self.stock_symbol_text.grid(row=0, column=0, padx=5, pady=5, sticky='w')
 
         self.text_input_box = Entry(self.input_frame, relief=SOLID, width=20, borderwidth=2, font=self.label_font)
@@ -53,17 +54,20 @@ class StartPage(tk.Frame):
         self.text_input_box.focus()
         self.text_input_box.bind('<Return>', self.analyze)
 
-        self.analyze_button = Button(self.input_frame, text='Analyze Stock', bg='#27ae60', fg='#ecf0f1', font=self.label_font, borderless=True, command=self.analyze)
+        self.analyze_button = Button(self.input_frame, text='Analyze Stock', bg='#27ae60', fg='#ecf0f1',
+                                     font=self.label_font, borderless=True, command=self.analyze)
         self.analyze_button.grid(row=0, column=2, padx=5, pady=5, sticky='w')
 
-        self.clear_button = Button(self.input_frame, text="Clear", bg='#c0392b', fg='#ecf0f1', font=self.label_font, borderless=True, command=self.clear_values)
+        self.clear_button = Button(self.input_frame, text="Clear", bg='#c0392b', fg='#ecf0f1', font=self.label_font,
+                                   borderless=True, command=self.clear_values)
         self.clear_button.grid(row=0, column=3, padx=5, pady=5, sticky='w')
 
         # Results Frame
         self.results_frame = Frame(self.content_frame, background='#34495e', bd=2, relief=SOLID)
         self.results_frame.grid(row=1, column=0, pady=5, padx=5, sticky='n')
 
-        self.company_name_label_text = Label(self.results_frame, text="", font=self.my_font, bg='#34495e', fg='#ecf0f1', anchor="w")
+        self.company_name_label_text = Label(self.results_frame, text="", font=self.my_font, bg='#34495e', fg='#ecf0f1',
+                                             anchor="w")
         self.company_name_label_text.grid(row=0, column=0, columnspan=2, pady=5)
 
         labels = [
@@ -76,12 +80,14 @@ class StartPage(tk.Frame):
         self.row_info = {}
 
         for i, label in enumerate(labels):
-            lbl = Label(self.results_frame, text=label, width=25, anchor="w", font=self.label_font, background='#34495e', fg='#ecf0f1')
+            lbl = Label(self.results_frame, text=label, width=25, anchor="w", font=self.label_font, background='#34495e',
+                        fg='#ecf0f1')
             lbl.grid(row=i + 1, column=0, padx=5, pady=5, sticky='w')
             canvas = Canvas(self.results_frame, width=200, height=20, bg='#34495e', highlightthickness=0)
             canvas.grid(row=i + 1, column=1, padx=5, pady=5, sticky='w')
             self.skeleton_loaders[label] = canvas
-            self.value_labels[label] = Label(self.results_frame, text="", width=25, anchor="w", font=self.label_font, background='#34495e', fg='#ecf0f1')
+            self.value_labels[label] = Label(self.results_frame, text="", width=25, anchor="w", font=self.label_font,
+                                             background='#34495e', fg='#ecf0f1')
             self.row_info[label] = {'row': i + 1, 'column': 1}
 
         self.parent.bind('<Return>', self.analyze)
@@ -95,7 +101,6 @@ class StartPage(tk.Frame):
 
             self.controller.after(0, self.clear_values)
             self.controller.after(0, lambda: self.set_widget_state('disabled'))
-            self.controller.after(0, self.set_skeleton_loaders)
 
             time.sleep(1)  # Simulate delay for demo purposes
             try:
@@ -123,29 +128,6 @@ class StartPage(tk.Frame):
         for widget in (self.text_input_box, self.analyze_button, self.clear_button):
             widget.config(state=state)
 
-    def set_skeleton_loaders(self):
-        for label, canvas in self.skeleton_loaders.items():
-            canvas.delete("all")
-            rect_id = canvas.create_rectangle(10, 2, 190, 18, fill="light gray", outline="")
-            self.animate_loader(canvas, rect_id, label)
-            canvas.lift(rect_id)
-            canvas.update_idletasks()
-            print(f"Loader set for {label}")
-
-    def animate_loader(self, canvas, rect_id, label):
-        colors = ["#ecf0f1", "#bdc3c7", "#7f8c8d"]
-        def animate_color(idx=0):
-            canvas.itemconfig(rect_id, fill=colors[idx])
-            next_idx = (idx + 1) % len(colors)
-            self.animation_ids[label] = canvas.after(300, animate_color, next_idx)
-            print(f"Animating {label} to color {colors[idx]}")
-        animate_color()
-
-    def stop_animation(self, label):
-        if label in self.animation_ids:
-            self.after_cancel(self.animation_ids[label])
-            del self.animation_ids[label]
-
     def update_company_name(self, value):
         self.company_name_label_text["text"] = value
 
@@ -161,13 +143,8 @@ class StartPage(tk.Frame):
             print(f"Label '{label}' not found in value_labels.")
 
     def _update_value_gui(self, label, value):
-        self.stop_animation(label)
-        row_info = self.row_info.get(label, {})
-        if row_info:
-            self.skeleton_loaders[label].grid_remove()
-            self.value_labels[label]["text"] = value
-            self.value_labels[label].grid(row=row_info["row"], column=row_info["column"], padx=5, pady=5, sticky='w')
-            print(f"Updated {label} to {value}")
+        self.value_labels[label]["text"] = value
+        print(f"Updated {label} to {value}")
 
     def get_text_input(self):
         return self.text_input_box.get().strip().upper()
@@ -208,11 +185,6 @@ class StartPage(tk.Frame):
         self.company_name_label_text["text"] = ""
         for label in self.value_labels.values():
             label["text"] = ""
-        for canvas in self.skeleton_loaders.values():
-            canvas.delete("all")
-        for label in self.animation_ids:
-            self.after_cancel(self.animation_ids[label])
-        self.animation_ids.clear()
 
     def clear_user_input_box(self):
         self.text_input_box.delete(0, END)


### PR DESCRIPTION
There is an issue on the main screen where the skelton loaders causes multiple windows to appear in the background and becomes apparent when you are closing the app. This is not ideal UX. This iimplementation needs to be revisited in a following PR.