### PR TITLE
fix: Fix double launch bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 tests/.coverage
 tests/.test-results
+dist/*

--- a/.pylintrc
+++ b/.pylintrc
@@ -289,9 +289,8 @@ exclude-too-few-public-methods=
 # R0901)
 ignored-parents=
 
-
 # Maximum number of arguments for function / method.
-max-args=8
+max-args=5
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=15

--- a/.pylintrc
+++ b/.pylintrc
@@ -289,8 +289,9 @@ exclude-too-few-public-methods=
 # R0901)
 ignored-parents=
 
+
 # Maximum number of arguments for function / method.
-max-args=5
+max-args=8
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=15

--- a/.pylintrc
+++ b/.pylintrc
@@ -319,6 +319,8 @@ max-statements=50
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=2
 
+# Maximum number of positional arguments (see R0917).
+max-positional-arguments = 10
 
 [EXCEPTIONS]
 

--- a/app/financials/analyze.py
+++ b/app/financials/analyze.py
@@ -13,8 +13,6 @@ Modules:
     price_data: Handles price data retrieval.
     ticker: Handles ticker symbol retrieval.
 
-Constants:
-    ERROR_MESSAGE (str): Error message to return in case of invalid stock symbol.
 
 Functions:
     get_company_sector(ticker_symbol)

--- a/app/pages/base_page.py
+++ b/app/pages/base_page.py
@@ -11,6 +11,8 @@ if platform.system() == "Darwin":
     from tkmacosx import Button
 else:
     from tkinter import Button
+
+
 class BasePage(tk.Frame):
     # pylint: disable=too-many-instance-attributes
     """
@@ -25,6 +27,7 @@ class BasePage(tk.Frame):
     yearly_text (str): The text value for the annual option in the radio button.
     bg_color (str): The background color of the frame.
     """
+
     # pylint: disable=line-too-long
 
     def __init__(self, parent, controller, title, quarterly_text, yearly_text, bg_color='#2C3E50', fg_color='white'):

--- a/user_interface.py
+++ b/user_interface.py
@@ -6,6 +6,7 @@ except ImportError:
     import tkinter as tk
 import sys
 import os
+import multiprocessing
 from PIL import Image, ImageTk
 
 from app.pages import (
@@ -116,10 +117,13 @@ class UserInterFace(tk.Tk):
 
 
 if __name__ == "__main__":
+
+    multiprocessing.freeze_support()  # This prevents double-execution
+
     try:
         app = UserInterFace()
         app.geometry("1200x800")
         app.protocol("WM_DELETE_WINDOW", app.on_closing)
         app.mainloop()
     except KeyboardInterrupt as e:
-        print("closing app")
+        print("Closing app")


### PR DESCRIPTION
The purpose of this pull request is to address an issue with the app doubling sometimes triple launching. The app launching sporadically is a limitation of pyinstaller. 

> ### Why It Happens
> When using PyInstaller, your app is bundled into a single executable. The way the executable is launched internally can sometimes trigger multiple __main__ invocations, especially on Windows. This behavior is often linked to the use of:
> 
> Multiprocessing (which can cause the script to fork itself).
> tkinter elements initialized in the wrong place.
> Code executed outside of the if __name__ == "__main__": guard. 

